### PR TITLE
Mark boot hart field as obsolete.

### DIFF
--- a/bibliography.adoc
+++ b/bibliography.adoc
@@ -2,3 +2,5 @@
 == Bibliography
 
 bibliography::[]
+
+* [[UEFI]]<<UEFI>> RISC-V UEFI PROTOCOL Specification 1.0.0, 2022, https://github.com/riscv-non-isa/riscv-uefi/releases/download/1.0.0/RISCV_UEFI_PROTOCOL-spec.pdf

--- a/riscv-smbios.adoc
+++ b/riscv-smbios.adoc
@@ -124,7 +124,9 @@ Structure is backward compatible with older version of this structure.
 | **Offset** | **Additional Info. Version** | **Name** | **Length** | **Value** | **Description**
 | 03h| 000Ah (v0.10)| Hart ID| DQWORD| Varies| The ID of this RISC-V Hart
 | 13h| 000Ah (v0.10)| Boot Hart| BYTE| Boolean| 1: This is boot hart to boot system +
-0: This is not the boot hart
+0: This is not the boot hart +
+This field is obsoleted by the RISC-V UEFI PROTOCOL Specification <<UEFI>> and
+should be ignored.
 | 14h| 000Ah (v0.10)| Machine Vendor ID | DQWORD| Varies| The vendor ID of this
 RISC-V Hart
 | 24h| 000Ah (v0.10)| Machine Architecture ID| DQWORD| Varies| Base


### PR DESCRIPTION
There should be a single way to retrieve the boot hart to avoid conflicts. We have the ratified RISC-V UEFI PROTOCOL Specification which is meant to be the source of truth for the boot hart.